### PR TITLE
Use pulp-manager rather than manage.py

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,25 +37,8 @@
   become: true
   become_user: postgres
 
-- name : Find manage.py
-  find:
-    paths: "{{ pulp_venv }}"
-    patterns: 'manage.py'
-    recurse: true
-  register: result
-
-- name: Ensure the manage.py was found
-  assert:
-    that: 'result["matched"] == 1'
-
-- name: Changing perm of manage.py, adding "+x"
-  file: dest={{ result["files"][0]["path"] }} mode=a+x
-
 - name: Run Django migrations
-  django_manage:
-    command: "{{ item }}"
-    app_path: '{{ result["files"][0]["path"]| dirname}}'
-    virtualenv: "{{ pulp_user_home }}/pulpvenv"
+  command: "{{pulp_venv}}/bin/pulp-manager {{item}}"
   with_items:
     - 'makemigrations pulp_app'
     - 'migrate --noinput auth'
@@ -63,6 +46,3 @@
     - 'reset-admin-password --password admin'
   become: true
   become_user: "{{ pulp_user }}"
-
-- name: Changing perm of manage.py, adding "-x"
-  file: dest={{ result["files"][0]["path"] }} mode=a-x


### PR DESCRIPTION
The pulp-manager tool has an entry point in the setup.py of platform, so
it is executable from the virtualenv without having to find the
manage.py.

re: #3012